### PR TITLE
docs: bump version to 2.2.2 and update docs for removeKeychain fix

### DIFF
--- a/DETAILED_DOCUMENTATION.md
+++ b/DETAILED_DOCUMENTATION.md
@@ -391,19 +391,13 @@ Applies a keychain to an item.
 
 ---
 
-##### `removeKeychain(itemId, keychainSlot, callback)`
-Removes a keychain from an item.
+##### `removeKeychain(itemId)`
+Removes a keychain from an item. This is a fire-and-forget operation — it sends the removal request to the Game Coordinator without waiting for a response.
 
 **Parameters:**
-- `itemId` (number) - The ID of the item with the keychain
-- `keychainSlot` (number) - The slot number of the keychain to remove
-- `callback` (function, optional) - Callback function `(err, itemIds) => {}`
+- `itemId` (string) - The ID of the item with the keychain
 
-**Returns:**
-- If callback provided: `undefined`
-- If no callback: `Promise<Array>` - Resolves with array of item IDs
-
-**Timeout:** Configurable via `_stickerTimeout` (default: 10000ms)
+**Returns:** `undefined`
 
 ---
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -662,20 +662,10 @@ cs2.applyKeychain(itemId, keychainId, keychainSlot, (err, itemIds) => {
 ### Remove Keychain
 
 ```javascript
-// Remove keychain from item
-const itemId = 1234567890;
-const keychainSlot = 0;
+// Remove keychain from item (fire-and-forget)
+const itemId = '1234567890';
 
-await cs2.removeKeychain(itemId, keychainSlot);
-
-// With callback
-cs2.removeKeychain(itemId, keychainSlot, (err, itemIds) => {
-    if (err) {
-        console.error('Error:', err);
-        return;
-    }
-    console.log('Keychain removed, items:', itemIds);
-});
+cs2.removeKeychain(itemId);
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Modern **CS2/CS:GO Game Coordinator integration** with the latest **GameTracking-CS2 protobuf definitions**. This package provides a simple API for interacting with the Counter-Strike 2 and CS:GO Game Coordinator, with full support for all modern CS2 features.
 
+> **Note:** Large portions of this library were generated with the assistance of AI. While core functionality has been verified, some features — particularly around volatile items — may not have been thoroughly tested and could behave unexpectedly. If you discover a bug or have a working fix for an open issue, I'd appreciate it if you could submit a Pull Request or leave a comment on the [GitHub Issue](https://github.com/sak0a/node-cs2/issues) with your solution. Community contributions help make this project better for everyone.
+
 ## Features
 
 -  **Latest Protobuf Definitions** - Always up-to-date with GameTracking-CS2
@@ -120,7 +122,7 @@ await cs2.removePatch(itemId, patchSlot);
 
 // Apply/remove keychains
 await cs2.applyKeychain(itemId, keychainId, keychainSlot);
-await cs2.removeKeychain(itemId, keychainSlot);
+cs2.removeKeychain(itemId);
 ```
 
 ## Documentation
@@ -167,6 +169,19 @@ MIT License - see [LICENSE](LICENSE) file for details.
 - **Fork Maintainer:** [sak0a](https://github.com/sak0a)
 
 ## Changelog
+
+### v2.2.2 (February 2026)
+
+**Bug Fixes:**
+- Fixed `removeKeychain()` always timing out — now uses `CMsgApplySticker` instead of `CMsgGCItemCustomizationNotification` ([#2](https://github.com/sak0a/node-cs2/issues/2))
+
+**Breaking Changes:**
+- `removeKeychain(itemId)` no longer accepts `keychainSlot` or `callback` parameters — it is now a fire-and-forget operation
+
+### v2.2.1 (January 2026)
+
+**Improvements:**
+- Updated README
 
 ### v2.2.0 (December 19, 2025)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-cs2",
-	"version": "2.2.1",
+	"version": "2.2.2",
 	"description": "Modern CS2/CS:GO Game Coordinator integration with latest GameTracking-CS2 protobuf definitions. Includes support for highlight_reel, wrapped_sticker, variations, Promise-based API, crate opening, sticker/patch/keychain operations, and all modern CS2 fields.",
 	"keywords": [
 		"cs2",


### PR DESCRIPTION
- Add AI disclaimer note to README
- Add v2.2.2 changelog entry for the removeKeychain bug fix
- Update removeKeychain usage across README, DETAILED_DOCUMENTATION.md, and EXAMPLES.md to reflect the simplified fire-and-forget API
- Bump package.json version to 2.2.2

https://claude.ai/code/session_01AKSEkFg5N61c7kt3VTmwUX